### PR TITLE
Update numpy trapz to trapezoid

### DIFF
--- a/src/roguewave/tools/time_integration.py
+++ b/src/roguewave/tools/time_integration.py
@@ -14,7 +14,7 @@ from numpy import (
     array,
     zeros,
     linspace,
-    trapz,
+    trapezoid,
 )
 from numpy.typing import NDArray
 
@@ -326,6 +326,6 @@ def integrated_response_factor_spectral_tail(
         else:
             spectrum[index] = integration_frequencies[index] ** tail_power
 
-    return trapz(spectrum, integration_frequencies) / trapz(
+    return trapezoid(spectrum, integration_frequencies) / trapezoid(
         abs(complex_amplification_factor) ** 2 * spectrum, integration_frequencies
     )

--- a/src/roguewave/wavephysics/balance/jb23_tail_stress.py
+++ b/src/roguewave/wavephysics/balance/jb23_tail_stress.py
@@ -14,7 +14,7 @@ from numpy import (
     zeros,
     concatenate,
     min,
-    trapz,
+    trapezoid,
 )
 
 from roguewave.wavephysics.balance.solvers import numba_newton_raphson
@@ -139,7 +139,7 @@ def tail_stress_parametrization_jb23(
         wavenumbers, roughness_length, friction_velocity, tail_spectrum, parameters
     )
     integral = (
-        trapz(stress, wavenumbers) + background_stress * parameters["air_density"]
+        trapezoid(stress, wavenumbers) + background_stress * parameters["air_density"]
     )
 
     eastward_stress = integral * stress_east_fac

--- a/src/roguewave/wavespectra/spectrum.py
+++ b/src/roguewave/wavespectra/spectrum.py
@@ -797,7 +797,7 @@ class WaveSpectrum(DatasetWrapper):
         range = {NAME_F: self._range(fmin, fmax)}
 
         property = property.fillna(0)
-        return numpy.trapz(
+        return numpy.trapezoid(
             property.isel(**range) * self.e.isel(**range), self.frequency[range]
         ) / self.m0(fmin, fmax)
 


### PR DESCRIPTION
The numpy `trapz` function was deprecated in 2.0, and as of 2.4 it has been removed entirely. This PR updates all calls to the equivalent `numpy.trapezoid`. 