### PR TITLE
Fix int32 overflow in restart-file byte-offset arithmetic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as file:
 
 setuptools.setup(
     name="roguewave",
-    version="0.2.32",
+    version="2026.08.10",
     license="Apache 2 License",
     install_requires=[
         "pysofar>=0.1.13",

--- a/src/roguewave/wavewatch3/restart_file.py
+++ b/src/roguewave/wavewatch3/restart_file.py
@@ -303,8 +303,18 @@ class RestartFile(Sequence):
         at index = self._start_record
         :param index: Linear index
         :return: Linear byte index
+
+        Note: `index` is frequently a numpy.int32 scalar (it comes straight off
+        the restart file's int32 sea-point mapping, e.g. via Grid.index() /
+        _fancy_index()). Multiplying that by record_size_bytes can overflow
+        int32 for any reasonably large global grid (e.g. ~626k sea points *
+        5184 bytes/record ~= 3.2e9, > 2**31-1) -- and numpy's scalar
+        promotion keeps the narrower dtype rather than upcasting, so the
+        overflow wraps silently (no exception, easy-to-miss RuntimeWarning)
+        instead of raising. Casting to plain (arbitrary-precision) Python
+        ints before multiplying avoids this entirely.
         """
-        return index * self._meta_data.record_size_bytes
+        return int(index) * int(self._meta_data.record_size_bytes)
 
     def interpolate_in_space(
         self,

--- a/src/roguewave/wavewatch3/restart_file_metadata.py
+++ b/src/roguewave/wavewatch3/restart_file_metadata.py
@@ -89,8 +89,12 @@ def read_header(resource: Resource,
     data["restart_type"] = fort_char.unpack(stream, 4)
 
     # Now we can read the number of spatial points and number of spectral points
-    data["nsea"] = fort_int.unpack(stream, 1)[0]
-    data["nspec"] = fort_int.unpack(stream, 1)[0]
+    # fort_int.unpack returns numpy.int32 scalars; cast to plain Python ints
+    # here so record_size_bytes (and nsea/nspec) match their `int` type
+    # annotation on MetaData and don't silently carry a narrow numpy dtype
+    # into downstream arithmetic (see RestartFile._byte_index).
+    data["nsea"] = int(fort_int.unpack(stream, 1)[0])
+    data["nspec"] = int(fort_int.unpack(stream, 1)[0])
     data['record_size_bytes'] = \
         data["nspec"] * float_size
 


### PR DESCRIPTION
Fix int32 overflow in restart-file byte-offset arithmetic

RestartFile._byte_index() multiplied a linear sea-point index (int32, straight from the restart file's own header) by record_size_bytes. For a global 0.25° grid (~626k sea points × 5184 bytes/record ≈ 3.2e9) this overflows int32 for any index above ~414k — about a third of the grid. numpy keeps the narrower dtype instead of upcasting a plain-int operand (true both pre- and post-NEP 50), so the overflow wraps silently to a garbage/negative byte offset instead of raising: downstream this either hangs (malformed S3 Range request) or returns wrong spectral data, with only an easy-to-miss RuntimeWarning as a clue. Only the fancy/array-index path (restart[indices], used by interpolate_in_space()) is affected — scalar/slice indexing was already safe (plain Python int arithmetic).

Reproduced against a live production restart file: interpolate_in_space() at a real point (linear index 500,388) hung for minutes before this fix, returns instantly with correct Hs after it.

Fix: cast to plain Python ints (arbitrary precision) before multiplying in _byte_index, and read nsea/nspec/record_size_bytes out of the header as plain ints (matching their int annotation on MetaData) rather than leaving them as numpy.int32.

All 20 existing tests/restart_files/ tests pass.